### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Licensed under the EUPL, Version 1.1 or – as soon they will be approved by the
  * We recommend you to use JsDelivr CDN files: 
 
  ````html
- <script type="text/javascript" src="http://cdn.jsdelivr.net/chcontext/1.2.0/chcontext.min.js"></script>
+ <script type="text/javascript" src="https://cdn.jsdelivr.net/gh/psnc-dl/chcontext@.1.2.0/dist/chcontext.min.js"></script>
  ````
- * or download [chcontext.min.js](http://cdn.jsdelivr.net/chcontext/1.2.0/chcontext.min.js), add it to your project and include it in your html using appropriate path.
+ * or download [chcontext.min.js](https://cdn.jsdelivr.net/gh/psnc-dl/chcontext@.1.2.0/dist/chcontext.min.js), add it to your project and include it in your html using appropriate path.
 
  ````html
  <script type="text/javascript" src="$PATH/chcontext.min.js"></script>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/psnc-dl/chcontext.

Feel free to ping me if you have any questions regarding this change.